### PR TITLE
Add interactive building map

### DIFF
--- a/infografias/tallest-buildings/index.html
+++ b/infografias/tallest-buildings/index.html
@@ -6,6 +6,9 @@
   <title>Infografías - Edificios</title>
   <script src="../extras/tailwind.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <style>
@@ -24,7 +27,7 @@
     </div>
   </nav>
   <main class="flex-grow max-w-6xl mx-auto p-4 space-y-6">
-    <h1 id="page-title" class="text-3xl font-bold text-center"></h1>
+    <h1 id="page-title" class="text-4xl text-center font-bold mb-2" style="font-family:'Playfair Display',serif;"></h1>
     <section class="grid md:grid-cols-2 gap-4 items-start">
       <div>
         <canvas id="heightChart" height="200"></canvas>
@@ -36,6 +39,7 @@
       </div>
     </section>
     <div id="map" class="h-96 w-full"></div>
+    <div id="map-info" class="hidden bg-white shadow rounded p-4 my-4"></div>
     <section id="cards" class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6"></section>
   </main>
   <footer class="text-center py-4 text-gray-500 text-xs">Fuente: CTBUH 2024</footer>
@@ -344,13 +348,41 @@ function createCards() {
 let mapInstance = null;
 function createMap() {
   if (mapInstance) { mapInstance.remove(); }
-  mapInstance = L.map('map').setView([20,0], 2);
+  mapInstance = L.map('map', {
+    maxBounds: [[-60,-180],[80,180]],
+    maxBoundsViscosity: 1.0,
+    minZoom: 2,
+    maxZoom: 7,
+    worldCopyJump: true
+  }).setView([20,0], 2);
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '© OpenStreetMap'
   }).addTo(mapInstance);
-  buildings.forEach(b => {
-    L.marker([b.lat, b.lng]).addTo(mapInstance).bindTooltip(b.name);
+  buildings.forEach((b,idx) => {
+    L.marker([b.lat, b.lng]).addTo(mapInstance)
+      .bindTooltip(b.name)
+      .on('click', () => showBuildingOnMap(idx));
   });
+}
+
+function showBuildingOnMap(idx) {
+  const b = buildings[idx];
+  const info = document.getElementById('map-info');
+  const cards = document.getElementById('cards');
+  info.innerHTML = `
+    <div class="flex justify-between items-center mb-2">
+      <h3 class="text-xl font-semibold">${b.name}</h3>
+      <button id="close-map-info" class="text-red-600 font-bold">X</button>
+    </div>
+    <p class="text-sm"><strong>${translations[currentLang].country}:</strong> ${currentLang==='es'?b.country_es:b.country_en}</p>
+    <p class="text-sm"><strong>${translations[currentLang].city}:</strong> ${b.city}</p>
+    <p class="mt-2 text-sm">${currentLang==='es'?b.info_es:b.info_en}</p>`;
+  info.classList.remove('hidden');
+  cards.classList.add('hidden');
+  document.getElementById('close-map-info').addEventListener('click', () => {
+    info.classList.add('hidden');
+    cards.classList.remove('hidden');
+  }, { once: true });
 }
 
 function updateLang(lang) {
@@ -360,6 +392,8 @@ function updateLang(lang) {
   document.getElementById('page-title').textContent = t.pageTitle;
   document.getElementById('height-label').textContent = t.heightLabel;
   document.getElementById('continents-title').textContent = t.continentsTitle;
+  document.getElementById('map-info').classList.add('hidden');
+  document.getElementById('cards').classList.remove('hidden');
   drawCharts();
   createCards();
   createMap();


### PR DESCRIPTION
## Summary
- style page title with Playfair Display Google Font
- add map info panel to show building details
- limit map panning and zoom levels
- show a card for a building when a map marker is clicked

## Testing
- `apt-get update`
- `apt-get install -y file`


------
https://chatgpt.com/codex/tasks/task_e_6848336d14688322b9afb13ae2770240